### PR TITLE
Activate PF Validator in sequence

### DIFF
--- a/SimDataFormats/Associations/src/classes_def.xml
+++ b/SimDataFormats/Associations/src/classes_def.xml
@@ -171,6 +171,8 @@
   <class name="edm::RefProd<std::vector<reco::PFCluster>>"/>
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<SimCluster> >,edm::RefProd<vector<reco::PFCluster> > >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::PFCluster> >,edm::RefProd<vector<SimCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::PFCluster> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::PFCluster> >,edm::RefProd<vector<CaloParticle> > >" />
 
   <class name="edm::AssociationMap<edm::OneToManyWithQualityGeneric<
             std::vector<SimCluster>, std::vector<reco::PFCluster>, std::pair<float,float>, unsigned int,
@@ -182,7 +184,18 @@
             edm::RefProd<std::vector<reco::PFCluster>>, edm::RefProd<std::vector<SimCluster>>,
             edm::Ref<std::vector<reco::PFCluster>>, edm::Ref<std::vector<SimCluster>>
         >>"/>
-        
+
+  <class name="edm::AssociationMap<edm::OneToManyWithQualityGeneric<
+            std::vector<CaloParticle>, std::vector<reco::PFCluster>, std::pair<float,float>, unsigned int,
+            edm::RefProd<std::vector<CaloParticle>>, edm::RefProd<std::vector<reco::PFCluster>>,
+            edm::Ref<std::vector<CaloParticle>>, edm::Ref<std::vector<reco::PFCluster>>
+        >>"/>
+  <class name="edm::AssociationMap<edm::OneToManyWithQualityGeneric<
+            std::vector<reco::PFCluster>, std::vector<CaloParticle>, float, unsigned int,
+            edm::RefProd<std::vector<reco::PFCluster>>, edm::RefProd<std::vector<CaloParticle>>,
+            edm::Ref<std::vector<reco::PFCluster>>, edm::Ref<std::vector<CaloParticle>>
+        >>"/>
+
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQualityGeneric<edm::View<reco::Track>,vector<TrackingParticle>,double,unsigned int,edm::RefToBaseProd<reco::Track>,edm::RefProd<vector<TrackingParticle> >,edm::RefToBase<reco::Track>,edm::Ref<vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<vector<TrackingParticle>,TrackingParticle> > > > >" />
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQualityGeneric<vector<TrackingParticle>,edm::View<reco::Track>,double,unsigned int,edm::RefProd<vector<TrackingParticle> >,edm::RefToBaseProd<reco::Track>,edm::Ref<vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<vector<TrackingParticle>,TrackingParticle> >,edm::RefToBase<reco::Track> > > >" />
 

--- a/Validation/HGCalValidation/interface/PFValidator.h
+++ b/Validation/HGCalValidation/interface/PFValidator.h
@@ -1,7 +1,7 @@
-#ifndef HGCalValidator_h
-#define HGCalValidator_h
+#ifndef PFValidator_h
+#define PFValidator_h
 
-/** \class HGCalValidator
+/** \class PFValidator
  *  Class that produces histograms to validate HGCal Reconstruction performances
  *
  *  \author HGCal

--- a/Validation/HGCalValidation/plugins/SealModule.cc
+++ b/Validation/HGCalValidation/plugins/SealModule.cc
@@ -2,7 +2,9 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "Validation/HGCalValidation/interface/HGCalValidator.h"
+#include "Validation/HGCalValidation/interface/PFValidator.h"
 #include "Validation/HGCalValidation/interface/BarrelValidator.h"
 
 DEFINE_FWK_MODULE(HGCalValidator);
+DEFINE_FWK_MODULE(PFValidator);
 DEFINE_FWK_MODULE(BarrelValidator);

--- a/Validation/RecoParticleFlow/python/hltPFValidation_cfi.py
+++ b/Validation/RecoParticleFlow/python/hltPFValidation_cfi.py
@@ -13,6 +13,14 @@ hltPFClusterSimClusterAssociationProducer = cms.EDProducer("PCToSCAssociatorEDPr
     label_scl = cms.InputTag("mix","MergedCaloTruth")
 )
 
+hltPFValidator = cms.EDProducer("PFValidator",
+    label_rcl = cms.InputTag("hltParticleFlowClusterHBHE"),
+    associator = cms.untracked.InputTag("hltPFClusterSimClusterAssociationProducer"),
+    associatorSim = cms.untracked.InputTag("hltPFClusterSimClusterAssociationProducer"),
+    label_scl = cms.InputTag("mix","MergedCaloTruth"),
+    doCaloParticlePlots = cms.untracked.bool(False),
+)
+
 hltPFTester = cms.EDProducer("PFTester",
     PFCand = cms.InputTag("hltParticleFlowTmp"),
     PFClusterHCAL = cms.InputTag("hltParticleFlowClusterHBHE"),
@@ -26,5 +34,6 @@ hltPFTester = cms.EDProducer("PFTester",
 PFValSeq = cms.Sequence(
     hltPFHBHEScAssocByEnergyScoreProducer
     +hltPFClusterSimClusterAssociationProducer
+    +hltPFValidator
     +hltPFTester
 )


### PR DESCRIPTION
#### PR description:

Activate PF Validator in sequence.

#### PR validation:

To run: 

```
cmsrel CMSSW_16_0_X_2025-09-21-2300
cd CMSSW_16_0_X_2025-09-21-2300/src/
cmsenv
git cms-init
git cms-rebase-topic bfonta:PF_Sim_Validation_Light
scram b -j 0 

cmsDriver.py step2 --step L1P2GT,HLT:@relvalRun4,VALIDATION:@hltValidation \
    --conditions auto:phase2_realistic_T33 --geometry ExtendedRun4D110 --era Phase2C17I13M9 \
    --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
    --datatier GEN-SIM-DIGI-RAW,DQMIO --eventcontent FEVTDEBUGHLT,DQMIO \
    --process HLTX --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
    --filein file:/eos/cms/store/relval/CMSSW_15_1_0_pre5/RelValQCD_FlatPt_15_3000HS_14/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_STD_Run4D110_PU-v1/2580000/0581f18d-bc36-4b10-b9b2-58593b7792af.root \
    --fileout file:step2.root \
    -n 10 --nThreads 0
```

Before adding types in the SimDataFormats/Associations/src/classes_def.xml the error was:

```
----- Begin Fatal Exception 22-Sep-2025 17:35:22 CEST-----------------------
An exception of category 'DictionaryNotFound' occurred while
   [0] Constructing the EventProcessor
   [1] Calling ProductRegistry::initializeLookupTables, checking dictionaries for consumed products
Exception Message:
No data dictionary found for the following classes:

  __atomic_base<atomic<atomic<tbb::detail::d2::list_node<unsigned long>*>*>*>
  __atomic_base<atomic<tbb::detail::d2::list_node<unsigned long>*>*>
  __atomic_base<bool>
  __atomic_base<tbb::detail::d2::list_node<unsigned long>*>
  __atomic_base<unsigned long>
  __hash_base<unsigned long,unsigned int>
  atomic<atomic<atomic<tbb::detail::d2::list_node<unsigned long>*>*>*>
  atomic<atomic<tbb::detail::d2::list_node<unsigned long>*>*>
  atomic<bool>
  atomic<tbb::detail::d2::list_node<unsigned long>*>
  atomic<unsigned long>
  binary_function<unsigned int,unsigned int,bool>
  edm::AssociationMap<edm::OneToManyWithQualityGeneric<vector<reco::PFCluster>,vector<CaloParticle>,float,unsigned int,edm::RefProd<vector<reco::PFCluster> >,edm::RefProd<vector<CaloParticle> >,edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> > > >
  edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::PFCluster> > >
  edm::helpers::KeyVal<edm::RefProd<vector<reco::PFCluster> >,edm::RefProd<vector<CaloParticle> > >
  equal_to<unsigned int>
  hash<unsigned int>
  tbb::detail::d1::hash_compare<unsigned int,hash<unsigned int>,equal_to<unsigned int> >
  tbb::detail::d1::segment_table<atomic<tbb::detail::d2::list_node<unsigned long>*>,tbb::detail::d1::tbb_allocator<pair<const unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > > > >,tbb::detail::d2::concurrent_unordered_base<tbb::detail::d2::concurrent_unordered_map_traits<unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > >,hash<unsigned int>,equal_to<unsigned int>,tbb::detail::d1::tbb_allocator<pair<const unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > > > >,false> >::unordered_segment_table,63>
  tbb::detail::d1::tbb_allocator<atomic<atomic<tbb::detail::d2::list_node<unsigned long>*>*> >
  tbb::detail::d2::concurrent_unordered_base<tbb::detail::d2::concurrent_unordered_map_traits<unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > >,hash<unsigned int>,equal_to<unsigned int>,tbb::detail::d1::tbb_allocator<pair<const unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > > > >,false> >
  tbb::detail::d2::concurrent_unordered_base<tbb::detail::d2::concurrent_unordered_map_traits<unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > >,hash<unsigned int>,equal_to<unsigned int>,tbb::detail::d1::tbb_allocator<pair<const unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > > > >,false> >::unordered_segment_table
  tbb::detail::d2::concurrent_unordered_map<unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > >,hash<unsigned int>,equal_to<unsigned int>,tbb::detail::d1::tbb_allocator<pair<const unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > > > > >
  tbb::detail::d2::list_node<unsigned long>

Most likely each dictionary was never generated, but it may
be that it was generated in the wrong package. Please add
(or move) the specification '<class name="whatever"/>' to
the appropriate classes_def.xml file along with any other
information needed there. For example, if this class has any
transient members, you need to specify them in classes_def.xml.
Also include the class header in classes.h

The list of types above was generated while checking for
dictionaries related to products declared to be consumed.
A type listed above might or might not be a type declared
to be consumed. Instead it might be the type of a data member,
base class, wrapped type or other object needed by a consumed
type.  Below is some additional information which lists
the types declared to be consumed by a module and which
are associated with the types whose dictionaries were not
found:

  edm::AssociationMap<edm::OneToManyWithQualityGeneric<std::vector<CaloParticle>,std::vector<reco::PFCluster>,std::pair<float,float>,unsigned int,edm::RefProd<std::vector<CaloParticle> >,edm::RefProd<std::vector<reco::PFCluster> >,edm::Ref<std::vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<std::vector<CaloParticle>,CaloParticle> >,edm::Ref<std::vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCluster>,reco::PFCluster> > > >
  edm::AssociationMap<edm::OneToManyWithQualityGeneric<std::vector<reco::PFCluster>,std::vector<CaloParticle>,float,unsigned int,edm::RefProd<std::vector<reco::PFCluster> >,edm::RefProd<std::vector<CaloParticle> >,edm::Ref<std::vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCluster>,reco::PFCluster> >,edm::Ref<std::vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<std::vector<CaloParticle>,CaloParticle> > > >

----- End Fatal Exception -------------------------------------------------
```

Now it is:

```
----- Begin Fatal Exception 23-Sep-2025 11:22:34 CEST-----------------------
An exception of category 'DictionaryNotFound' occurred while
   [0] Constructing the EventProcessor
   [1] Calling ProductRegistry::initializeLookupTables, checking dictionaries for consumed products
Exception Message:
No data dictionary found for the following classes:

  __atomic_base<atomic<atomic<tbb::detail::d2::list_node<unsigned long>*>*>*>
  __atomic_base<atomic<tbb::detail::d2::list_node<unsigned long>*>*>
  __atomic_base<bool>
  __atomic_base<tbb::detail::d2::list_node<unsigned long>*>
  __atomic_base<unsigned long>
  __hash_base<unsigned long,unsigned int>
  atomic<atomic<atomic<tbb::detail::d2::list_node<unsigned long>*>*>*>
  atomic<atomic<tbb::detail::d2::list_node<unsigned long>*>*>
  atomic<bool>
  atomic<tbb::detail::d2::list_node<unsigned long>*>
  atomic<unsigned long>
  binary_function<unsigned int,unsigned int,bool>
  equal_to<unsigned int>
  hash<unsigned int>
  tbb::detail::d1::hash_compare<unsigned int,hash<unsigned int>,equal_to<unsigned int> >
  tbb::detail::d1::segment_table<atomic<tbb::detail::d2::list_node<unsigned long>*>,tbb::detail::d1::tbb_allocator<pair<const unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > > > >,tbb::detail::d2::concurrent_unordered_base<tbb::detail::d2::concurrent_unordered_map_traits<unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > >,hash<unsigned int>,equal_to<unsigned int>,tbb::detail::d1::tbb_allocator<pair<const unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > > > >,false> >::unordered_segment_table,63>
  tbb::detail::d1::tbb_allocator<atomic<atomic<tbb::detail::d2::list_node<unsigned long>*>*> >
  tbb::detail::d2::concurrent_unordered_base<tbb::detail::d2::concurrent_unordered_map_traits<unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > >,hash<unsigned int>,equal_to<unsigned int>,tbb::detail::d1::tbb_allocator<pair<const unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > > > >,false> >
  tbb::detail::d2::concurrent_unordered_base<tbb::detail::d2::concurrent_unordered_map_traits<unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > >,hash<unsigned int>,equal_to<unsigned int>,tbb::detail::d1::tbb_allocator<pair<const unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > > > >,false> >::unordered_segment_table
  tbb::detail::d2::concurrent_unordered_map<unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > >,hash<unsigned int>,equal_to<unsigned int>,tbb::detail::d1::tbb_allocator<pair<const unsigned int,edm::helpers::KeyVal<edm::Ref<vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<vector<reco::PFCluster>,reco::PFCluster> >,vector<pair<edm::Ref<vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<vector<CaloParticle>,CaloParticle> >,float> > > > > >
  tbb::detail::d2::list_node<unsigned long>

Most likely each dictionary was never generated, but it may
be that it was generated in the wrong package. Please add
(or move) the specification '<class name="whatever"/>' to
the appropriate classes_def.xml file along with any other
information needed there. For example, if this class has any
transient members, you need to specify them in classes_def.xml.
Also include the class header in classes.h

The list of types above was generated while checking for
dictionaries related to products declared to be consumed.
A type listed above might or might not be a type declared
to be consumed. Instead it might be the type of a data member,
base class, wrapped type or other object needed by a consumed
type.  Below is some additional information which lists
the types declared to be consumed by a module and which
are associated with the types whose dictionaries were not
found:

  edm::AssociationMap<edm::OneToManyWithQualityGeneric<std::vector<reco::PFCluster>,std::vector<CaloParticle>,float,unsigned int,edm::RefProd<std::vector<reco::PFCluster> >,edm::RefProd<std::vector<CaloParticle> >,edm::Ref<std::vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCluster>,reco::PFCluster> >,edm::Ref<std::vector<CaloParticle>,CaloParticle,edm::refhelper::FindUsingAdvance<std::vector<CaloParticle>,CaloParticle> > > >

----- End Fatal Exception -------------------------------------------------
```